### PR TITLE
[MotoSleep] Expand massage support for 3-motor motosleep beds

### DIFF
--- a/src/MotoSleep/CommandBuilder.ts
+++ b/src/MotoSleep/CommandBuilder.ts
@@ -52,7 +52,7 @@ export const buildCommands = (name: string) => {
     );
   }
   if (
-    (['3', '4', '8'].includes(remoteType) && motorNumber === '5') ||
+    (['3', '4', '8'].includes(remoteType) && ['3', '5'].includes(motorNumber)) ||
     ['A', 'B'].includes(remoteType) ||
     (remoteType === '7' && motorNumber !== '5') ||
     (remoteType === '9' && ['5', '6', '7', '8'].includes(motorNumber))
@@ -63,7 +63,7 @@ export const buildCommands = (name: string) => {
       buildCommand('Stop', 'D')
     );
   }
-  if ((remoteType === '4' && motorNumber === '5') || remoteType === '0') {
+  if ((remoteType === '4' && ['3', '5'].includes(motorNumber)) || remoteType === '0') {
     commands.push(buildCommand('MassageHeadOff', 'J'), buildCommand('MassageFootOff', 'I'));
   }
 


### PR DESCRIPTION
My MotoSleep bed has remote type 4 with 3 motors, but also supports head and foot massage similarly to remote 4 with 5 motors. This PR expands the conditionals to allow setting up buttons for toggling these massage settings for bed variants with 3 motors.