### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Support for this was only possible due to assistance from getrav on Discord. Thi
 
 ## Configuring
 
-You must specify at least one bleProxy as demonstrated in the config defaults. You also need to supply at least one Linak controller with `name`, `friendlyName`, and optionally `hasMassage`
+You must specify at least one bleProxy as demonstrated in the config defaults. You also need to supply at least one Linak controller with `name`, `friendlyName`, and optionally `hasMassage`. The `name` should be equal to the bluetooth device name ex. `bed 01234`.
 
 ## Current features include:
 


### PR DESCRIPTION
Added extra description to `LINAK` options. The `name` must be equal to the bluetooth device name (or it won't work).