### PR TITLE
fix missing lumbar control

### DIFF
--- a/src/Sleeptracker/processors/motorEntities.ts
+++ b/src/Sleeptracker/processors/motorEntities.ts
@@ -28,7 +28,7 @@ export const setupMotorEntities = async (
     user,
     entities,
     capability: {
-      motorRoster: { head, foot, headTilt: tilt, lumber: lumbar },
+      motorRoster: { head, foot, headTilt: tilt, lumbar },
     },
   }: Controller
 ) => {

--- a/src/Sleeptracker/types/HelloData.ts
+++ b/src/Sleeptracker/types/HelloData.ts
@@ -5,14 +5,14 @@ export type Capability = {
     foot: boolean;
     head: boolean;
     headTilt: boolean;
-    lumber: boolean;
+    lumbar: boolean;
   };
   memSlotCount: number;
   motorRoster: {
     foot: boolean;
     head: boolean;
     headTilt: boolean;
-    lumber: boolean;
+    lumbar: boolean;
   };
   side: 0 | 1;
 };


### PR DESCRIPTION
Issue - https://github.com/richardhopton/smartbed-mqtt/issues/58

* Typo "lumber" -> lumbar 🪵

Example helloData payload for Ergo ProSmart

```json
{
    "motorMeta": {
        "capabilities": [
            {
                "controllerModel": "BEST",
                "controllerVersion": 83,
                "massageRoster": {
                    "foot": true,
                    "head": true,
                    "headTilt": false,
                    "lumbar": false
                },
                "memSlotCount": 4,
                "motorRoster": {
                    "foot": true,
                    "head": true,
                    "headTilt": false,
                    "lumbar": true
                },
                "side": 0
            }
        ]
    }
}
```