### PR TITLE
Change polling delay to seconds vs minutes for sleeptracker

### DIFF
--- a/config.json
+++ b/config.json
@@ -15,7 +15,7 @@
     "mqtt_user": "<auto_detect>",
     "mqtt_password": "<auto_detect>",
     "type": "sleeptracker",
-    "sleeptrackerRefreshFrequency": 1,
+    "sleeptrackerRefreshFrequency": 60,
     "sleeptrackerCredentials": [
       {
         "email": "me@example.org",

--- a/src/Sleeptracker/sleeptracker.ts
+++ b/src/Sleeptracker/sleeptracker.ts
@@ -2,7 +2,7 @@ import { IMQTTConnection } from '@mqtt/IMQTTConnection';
 import { Dictionary } from '@utils/Dictionary';
 import { getSideNameFunc } from '@utils/getSideNameFunc';
 import { logError, logInfo } from '@utils/logger';
-import { minutes } from '@utils/minutes';
+import { seconds } from '@utils/seconds';
 import { buildEntityConfig } from 'Sleeptracker/buildEntityConfig';
 import { buildMQTTDeviceData } from './buildMQTTDeviceData';
 import { DeviceInfoSensor } from './entities/DeviceInfoSensor';
@@ -134,5 +134,5 @@ export const sleeptracker = async (mqtt: IMQTTConnection) => {
     }
   };
   await refreshDeviceData();
-  setInterval(refreshDeviceData, minutes(getRefreshFrequency()));
+  setInterval(refreshDeviceData, seconds(getRefreshFrequency()));
 };


### PR DESCRIPTION
Taking a full minute to update sensors is not always fast enough so this change allows the polling delay to be provided in seconds vs minutes. The default delay of one minute is still maintained, but it can now be further reduced if needed.