### PR TITLE
feat(sleeptracker): Add ActiveBreeze fan/climate control support

### DIFF
--- a/src/Sleeptracker/processors/fanEntities.ts
+++ b/src/Sleeptracker/processors/fanEntities.ts
@@ -1,0 +1,125 @@
+import { Select } from '@ha/Select';
+import { Switch } from '@ha/Switch';
+import { IMQTTConnection } from '@mqtt/IMQTTConnection';
+import { buildEntityConfig } from 'Sleeptracker/buildEntityConfig';
+import { sendFanCommand } from '../requests/sendFanCommand';
+import { sendAdjustableBaseCommand } from '../requests/sendAdjustableBaseCommand';
+import { Bed } from '../types/Bed';
+import { Commands } from '../types/Commands';
+import { Controller } from '../types/Controller';
+import { FanState, Snapshot } from '../types/Snapshot';
+
+const FAN_SPEED_OPTIONS = ['Off', 'Low', 'Medium', 'High'];
+
+interface FanEntitiesCache {
+  fanSpeed?: Select;
+  fanHeating?: Switch;
+}
+
+const getSideState = (fan: FanState, side: 0 | 1) => {
+  if (side === 0) {
+    return {
+      level: fan.leftLevel,
+      isHeating: fan.leftIsHeating,
+      isConstant: fan.leftIsConstant,
+      timer: fan.leftTimer,
+    };
+  }
+  return {
+    level: fan.rightLevel,
+    isHeating: fan.rightIsHeating,
+    isConstant: fan.rightIsConstant,
+    timer: fan.rightTimer,
+  };
+};
+
+const getSideKey = (side: 0 | 1): 'left' | 'right' => (side === 0 ? 'left' : 'right');
+
+export const processFanEntities = async (
+  mqtt: IMQTTConnection,
+  { deviceData }: Bed,
+  { sideName, entities, user, side }: Controller,
+  snapshot: Snapshot
+) => {
+  const fan = snapshot.fan;
+  if (!fan) return;
+
+  const cache = entities as FanEntitiesCache;
+  const sideKey = getSideKey(side);
+  const sideState = getSideState(fan, side);
+
+  // Fan Speed Select (Off / Low / Medium / High)
+  if (!cache.fanSpeed) {
+    cache.fanSpeed = new Select(
+      mqtt,
+      deviceData,
+      {
+        options: FAN_SPEED_OPTIONS,
+        icon: 'mdi:fan',
+        ...buildEntityConfig('Fan Speed', sideName),
+      },
+      async (state: string) => {
+        const level = FAN_SPEED_OPTIONS.indexOf(state);
+        await sendFanCommand(
+          sideKey,
+          {
+            level,
+            isHeating: sideState.isHeating,
+            isConstant: sideState.isConstant,
+          },
+          user
+        );
+        // Refresh state after command
+        const results = await sendAdjustableBaseCommand(Commands.Status, user);
+        const updated = results.find((r) => r.side === side);
+        if (updated?.fan) {
+          const newState = getSideState(updated.fan, side);
+          sideState.level = newState.level;
+          sideState.isHeating = newState.isHeating;
+          sideState.isConstant = newState.isConstant;
+          sideState.timer = newState.timer;
+          cache.fanHeating?.setState(newState.isHeating);
+        }
+        return FAN_SPEED_OPTIONS[level];
+      }
+    ).setOnline();
+  }
+  cache.fanSpeed.setState(FAN_SPEED_OPTIONS[sideState.level] || 'Off');
+
+  // Fan Heating/Cooling Mode Switch
+  if (!cache.fanHeating) {
+    cache.fanHeating = new Switch(
+      mqtt,
+      deviceData,
+      {
+        icon: 'mdi:heat-wave',
+        ...buildEntityConfig('Fan Heating', sideName),
+      },
+      async (state: boolean) => {
+        if (sideState.level === 0) return state; // No-op if fan is off
+        await sendFanCommand(
+          sideKey,
+          {
+            level: sideState.level,
+            isHeating: state,
+            isConstant: sideState.isConstant,
+          },
+          user
+        );
+        // Refresh state
+        const results = await sendAdjustableBaseCommand(Commands.Status, user);
+        const updated = results.find((r) => r.side === side);
+        if (updated?.fan) {
+          const newState = getSideState(updated.fan, side);
+          sideState.level = newState.level;
+          sideState.isHeating = newState.isHeating;
+          sideState.isConstant = newState.isConstant;
+          sideState.timer = newState.timer;
+          cache.fanSpeed?.setState(FAN_SPEED_OPTIONS[newState.level] || 'Off');
+        }
+        return state;
+      }
+    ).setOnline();
+  }
+  cache.fanHeating.setState(sideState.isHeating);
+};

--- a/src/Sleeptracker/requests/sendFanCommand.ts
+++ b/src/Sleeptracker/requests/sendFanCommand.ts
@@ -1,0 +1,35 @@
+import { Credentials } from '../options';
+import { sendProcessorCommand } from './sendProcessorCommand';
+
+const COOLING_TIMER = 36000; // 10 hours
+const HEATING_TIMER = 3600; // 1 hour
+
+export type FanCommandOptions = {
+  level: number; // 0=off, 1=low, 2=medium, 3=high
+  isHeating: boolean;
+  isConstant: boolean;
+};
+
+const buildSidePayload = (prefix: 'left' | 'right', options: FanCommandOptions) => ({
+  [`${prefix}IsConstant`]: options.isConstant,
+  [`${prefix}IsHeating`]: options.isHeating,
+  [`${prefix}Level`]: options.level,
+  [`${prefix}Timer`]: options.level === 0 ? 0 : options.isHeating ? HEATING_TIMER : COOLING_TIMER,
+});
+
+export const sendFanCommand = async (
+  side: 'left' | 'right',
+  options: FanCommandOptions,
+  credentials: Credentials
+) => {
+  const fanControl = {
+    position: { side: 0 },
+    ...buildSidePayload(side, options),
+  };
+
+  return sendProcessorCommand(
+    '/command/v1/motor-command',
+    { fanControl },
+    credentials
+  );
+};

--- a/src/Sleeptracker/requests/sendProcessorCommand.ts
+++ b/src/Sleeptracker/requests/sendProcessorCommand.ts
@@ -1,0 +1,39 @@
+import { Dictionary } from '@utils/Dictionary';
+import { logError } from '@utils/logger';
+import axios from 'axios';
+import { Credentials } from '../options';
+import { getAuthHeader } from './getAuthHeader';
+import defaultHeaders from './shared/defaultHeaders';
+import { buildDefaultPayload } from './shared/defaultPayload';
+import { urls } from './shared/urls';
+
+export const sendProcessorCommand = async (
+  endpoint: string,
+  processorCommand: Dictionary<any>,
+  credentials: Credentials
+) => {
+  const authHeader = await getAuthHeader(credentials);
+  if (!authHeader) return null;
+
+  const { appHost, processorBaseUrl } = urls(credentials);
+  try {
+    const response = await axios.request({
+      method: 'POST',
+      url: `${processorBaseUrl}/processorCommand`,
+      headers: {
+        ...defaultHeaders,
+        Host: appHost,
+        Authorization: authHeader,
+      },
+      data: {
+        ...buildDefaultPayload('processorCommand', credentials),
+        endpoint,
+        processorCommand,
+      },
+    });
+    return response.data;
+  } catch (err) {
+    logError(err);
+    return null;
+  }
+};

--- a/src/Sleeptracker/requests/shared/defaultPayload.ts
+++ b/src/Sleeptracker/requests/shared/defaultPayload.ts
@@ -7,7 +7,8 @@ type Context =
   | 'getSensorMap'
   | 'latestEnvironmentSensorData'
   | 'setSnoreRelief'
-  | 'adjustableBaseControls';
+  | 'adjustableBaseControls'
+  | 'processorCommand';
 
 const contextMap = {
   session: 'getUserSession',
@@ -17,6 +18,7 @@ const contextMap = {
   latestEnvironmentSensorData: 'environmentalData',
   setSnoreRelief: 'setSnoreRelief',
   adjustableBaseControls: 'adjustableBaseControls',
+  processorCommand: 'adjustableBaseControls',
 };
 
 const getClientFields = (type?: Type) => {

--- a/src/Sleeptracker/sleeptracker.ts
+++ b/src/Sleeptracker/sleeptracker.ts
@@ -11,6 +11,7 @@ import { SleepSensorInfoSensor } from './entities/SensorMapInfoSensor';
 import { getRefreshFrequency, getUsers } from './options';
 import { processBedPositionSensors } from './processors/bedPositionSensors';
 import { processEnvironmentSensors } from './processors/environmentSensors';
+import { processFanEntities } from './processors/fanEntities';
 import { setupMassageButtons } from './processors/massageButtons';
 import { processMassageSensors } from './processors/massageSensors';
 import { setupPresetButtons } from './processors/presetButtons';
@@ -61,6 +62,7 @@ export const sleeptracker = async (mqtt: IMQTTConnection) => {
             antiSnorePreset: antiSnorePresetSupported,
             environmentSensors: helloData.productFeatures.includes('env_sensors'),
             motors: helloData.productFeatures.includes('motors'),
+            fanController: helloData.productFeatures.includes('fan_controller'),
           },
           data: { headAngleTicksPerDegree, footAngleTicksPerDegree },
           entities: {
@@ -111,7 +113,7 @@ export const sleeptracker = async (mqtt: IMQTTConnection) => {
   const refreshDeviceData = async () => {
     for (const bed of Object.values(beds)) {
       logInfo('[Sleeptracker] Fetching data for bed', bed.processorId);
-      const { smartBedControls, environmentSensors, motors } = bed.supportedFeatures;
+      const { smartBedControls, environmentSensors, motors, fanController } = bed.supportedFeatures;
       if (smartBedControls) {
         const snapshots = await sendAdjustableBaseCommand(Commands.Status, bed.primaryUser);
         for (const controller of bed.controllers) {
@@ -128,6 +130,8 @@ export const sleeptracker = async (mqtt: IMQTTConnection) => {
           await processMassageSensors(mqtt, bed, controller, snapshot);
 
           await processSafetyLightSwitches(mqtt, bed, controller, snapshot);
+
+          if (fanController) await processFanEntities(mqtt, bed, controller, snapshot);
         }
       }
       if (environmentSensors) await processEnvironmentSensors(mqtt, bed);

--- a/src/Sleeptracker/types/Bed.ts
+++ b/src/Sleeptracker/types/Bed.ts
@@ -23,6 +23,7 @@ export type Bed = {
     antiSnorePreset: boolean;
     environmentSensors: boolean;
     motors: boolean;
+    fanController: boolean;
   };
   data: {
     headAngleTicksPerDegree: number;

--- a/src/Sleeptracker/types/Snapshot.ts
+++ b/src/Sleeptracker/types/Snapshot.ts
@@ -19,6 +19,17 @@ export enum MassagePattern {
   Ripple = 3,
 }
 
+export type FanState = {
+  leftIsConstant: boolean;
+  leftIsHeating: boolean;
+  leftLevel: number;
+  leftTimer: number;
+  rightIsConstant: boolean;
+  rightIsHeating: boolean;
+  rightLevel: number;
+  rightTimer: number;
+};
+
 export type Snapshot = {
   cableTime: number;
   foot: MassageMotorStatus;
@@ -30,6 +41,7 @@ export type Snapshot = {
   massageTimerSecs: number;
   safetyLightOn: boolean;
   side: 0 | 1;
+  fan?: FanState;
 };
 /*
     "timeIsSet": true,


### PR DESCRIPTION
# feat(sleeptracker): Add ActiveBreeze fan/climate control support

## Summary

Adds support for the **ActiveBreeze** fan/climate control system found in Sleeptracker AI-equipped beds (e.g., Tempur-Pedic ActiveBreeze). This creates per-side fan speed and heating mode controls that appear in Home Assistant via MQTT discovery.

## What is ActiveBreeze?

ActiveBreeze is a bed climate control system integrated into some Tempur-Pedic and other Sleeptracker-equipped beds. It provides per-side heating and cooling at three intensity levels (Low, Medium, High), with an automatic step-down timer system.

## Discovery Process

The fan control API was reverse-engineered from the Sleeptracker Android APK (v1.9.47). Key findings:

1. **Fan control uses a different endpoint** than motor/preset controls:
   - Motors/presets: `POST /processor/adjustableBaseControls`
   - Fan control: `POST /processor/processorCommand`

2. **The payload structure wraps the command differently:**
   ```json
   {
     "clientID": "sleeptracker-android-tsi",
     "clientVersion": "1.9.47",
     "id": "TEST_ANDROID_adjustableBaseControls",
     "endpoint": "/command/v1/motor-command",
     "processorCommand": {
       "fanControl": {
         "position": { "side": 0 },
         "leftIsConstant": false,
         "leftIsHeating": false,
         "leftLevel": 2,
         "leftTimer": 36000
       }
     }
   }
   ```

3. **Fan state is already returned** in the existing `adjustableBaseControls` status response under a `fan` key — no additional polling needed.

4. **Timer values are set automatically** by the app:
   - Cooling: `36000` seconds (10 hours)
   - Heating: `3600` seconds (1 hour)
   - These match the app's behavior — heating auto-stops after 1 hour for safety

5. **Fan levels:** 0=Off, 1=Low, 2=Medium, 3=High

6. **Per-side control:** Left side uses `leftLevel`/`leftIsHeating`/`leftIsConstant`/`leftTimer`, right side uses `right*` equivalents. The `position.side` is always `0`.

## Home Assistant Entities Created

For each bed side (Left/Right):

| Entity | Type | Description |
|--------|------|-------------|
| **Fan Speed** | `select` | Off / Low / Medium / High |
| **Fan Heating** | `switch` | ON = Heating mode, OFF = Cooling mode |

## Changes

### New Files
- `src/Sleeptracker/requests/sendProcessorCommand.ts` — Generic method for the `/processor/processorCommand` endpoint
- `src/Sleeptracker/requests/sendFanCommand.ts` — Fan-specific command builder with timer logic
- `src/Sleeptracker/processors/fanEntities.ts` — MQTT entity setup for fan speed select + heating mode switch

### Modified Files
- `src/Sleeptracker/types/Snapshot.ts` — Added `FanState` type and optional `fan` field to `Snapshot`
- `src/Sleeptracker/types/Bed.ts` — Added `fanController` to `supportedFeatures`
- `src/Sleeptracker/requests/shared/defaultPayload.ts` — Added `processorCommand` context
- `src/Sleeptracker/sleeptracker.ts` — Wire up fan entity processing, detect `fan_controller` feature

## Feature Detection

The fan controller feature is detected via `helloData.productFeatures` containing `'fan_controller'`. The existing adjustable base status response already includes the `fan` object when the feature is present — this PR simply reads it and exposes controls.

## Testing Notes

- Tested with a Tempur-Pedic bed with ActiveBreeze (Sleeptracker AI processor)
- Fan state is read from the existing status snapshot, so no additional API calls are needed for state polling
- Commands are sent via the new `processorCommand` endpoint and state is refreshed via a status poll after each command
- The `isConstant` flag (disables step-down mode) is preserved from current state when changing speed/mode

## Related APK Source References

From decompiled `com.fullpower.actrack.a` (API client):
```java
// Left side fan command
D("/processor/processorCommand", str, "TEST_ANDROID_adjustableBaseControls",
  new JsonDict()
    .a("endpoint", "/command/v1/motor-command")
    .a("processorCommand", new JsonDict()
      .a("fanControl", new JsonDict()
        .a("position", new JsonDict().a("side", 0))
        .a("leftIsConstant", Boolean.valueOf(z11))
        .a("leftIsHeating", Boolean.valueOf(z10))
        .a("leftLevel", Integer.valueOf(i10))
        .a("leftTimer", Integer.valueOf(z10 ? 3600 : 36000)))));
```

From `ClimateControl.java` — fan state parsed from snapshot:
```java
if (jsonDict2.e("fan")) {
    JsonDict n11 = jsonDict2.n("fan");
    // reads leftLevel, leftIsHeating, rightLevel, rightIsHeating, etc.
}
```
