### PR TITLE
fix: update Tempur Sleeptracker client version to 1.11.5

### DIFF
--- a/src/Sleeptracker/requests/shared/defaultPayload.ts
+++ b/src/Sleeptracker/requests/shared/defaultPayload.ts
@@ -26,7 +26,7 @@ const getClientFields = (type?: Type) => {
       return { clientID: 'sleeptracker-android', clientVersion: '6.5.15' };
     case 'tempur':
     default:
-      return { clientID: 'sleeptracker-android-tsi', clientVersion: '1.9.47' };
+      return { clientID: 'sleeptracker-android-tsi', clientVersion: '1.11.5' };
   }
 };
 export const buildDefaultPayload = (context: Context, { type }: Credentials) => ({


### PR DESCRIPTION
## Problem

The Sleeptracker cloud API returns **503 Service Unavailable** when the client reports version `1.9.47`. This affects all Tempur-type beds, causing the addon to fail on every polling cycle with:

```
PostRequest.postRequest: HTTP error: HttpStatusLine: caller: PostRequest.postRequest statusCode: 503 reasonPhrase: Service Unavailable
TypeError: Cannot read properties of null (reading 'snapshots')
```

## Root Cause

The current Tempur Sleeptracker app is **version 1.11.5**, but the addon reports `clientVersion: '1.9.47'` in the API payload. Tempur's API appears to reject requests from outdated client versions.

## Fix

Update the reported `clientVersion` from `1.9.47` to `1.11.5` in `defaultPayload.ts`.

## Testing

Tested on a Tempur-Pedic bed (bed ID 124087) — after updating the version string, 503 errors stopped immediately and data fetching resumed normally.

Fixes #78