### PR TITLE
(Sleeptracker) Include side name on adjustable base motor covers

### DIFF
--- a/src/Sleeptracker/processors/motorEntities.test.ts
+++ b/src/Sleeptracker/processors/motorEntities.test.ts
@@ -1,0 +1,66 @@
+import { IMQTTConnection } from '@mqtt/IMQTTConnection';
+import { mocked, testDevice } from '@utils/testHelpers';
+import { mock } from 'jest-mock-extended';
+import { loadStrings } from '@utils/getString';
+import { Bed } from 'Sleeptracker/types/Bed';
+import { Capability } from 'Sleeptracker/types/HelloData';
+import { Controller } from 'Sleeptracker/types/Controller';
+import { setupMotorEntities } from './motorEntities';
+
+const mqtt = mock<IMQTTConnection>();
+
+const buildCapability = (side: 0 | 1): Capability => ({
+  controllerModel: 'test',
+  controllerVersion: 1,
+  massageRoster: { foot: false, head: false, headTilt: false, lumber: false },
+  memSlotCount: 0,
+  motorRoster: { foot: true, head: true, headTilt: false, lumber: false },
+  side,
+});
+
+const buildController = (side: 0 | 1, sideName: string): Controller => ({
+  user: { email: 'email', password: 'password' },
+  side,
+  sideName,
+  entities: {},
+  capability: buildCapability(side),
+});
+
+const bed = { deviceData: testDevice } as unknown as Bed;
+
+const coverUniqueIds = () =>
+  mocked(mqtt.publish)
+    .mock.calls.filter(([topic]) => typeof topic === 'string' && topic.startsWith('homeassistant/cover/'))
+    .map(([, config]) => (config as { unique_id: string }).unique_id);
+
+describe(setupMotorEntities.name, () => {
+  beforeAll(async () => {
+    await loadStrings();
+    jest.useFakeTimers();
+  });
+  beforeEach(jest.resetAllMocks);
+
+  // Both sides of a split-king share one processor (one device), so their motor
+  // covers must carry the side in unique_id/topic or they collide and only one
+  // side's covers reach Home Assistant.
+  it('suffixes the side name onto each cover for a dual-controller bed', async () => {
+    await setupMotorEntities(mqtt, bed, buildController(1, 'Right'));
+    await setupMotorEntities(mqtt, bed, buildController(0, 'Left'));
+    jest.runAllTimers();
+
+    const ids = coverUniqueIds();
+    expect(ids).toEqual(
+      expect.arrayContaining(['test_name_head_right', 'test_name_feet_right', 'test_name_head_left', 'test_name_feet_left'])
+    );
+    // Regression: no two covers may share a unique_id (the collision bug).
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('omits the side suffix for a single-controller bed', async () => {
+    await setupMotorEntities(mqtt, bed, buildController(0, ''));
+    jest.runAllTimers();
+
+    const ids = coverUniqueIds();
+    expect(ids).toEqual(expect.arrayContaining(['test_name_head', 'test_name_feet']));
+  });
+});

--- a/src/Sleeptracker/processors/motorEntities.ts
+++ b/src/Sleeptracker/processors/motorEntities.ts
@@ -1,7 +1,7 @@
 import { IMQTTConnection } from '@mqtt/IMQTTConnection';
-import { StringsKey } from '@utils/getString';
+import { StringsKey, getString } from '@utils/getString';
 import { Cover } from '@ha/Cover';
-import { buildEntityConfig } from 'Common/buildEntityConfig';
+import { buildEntityConfig } from 'Sleeptracker/buildEntityConfig';
 import { Bed } from 'Sleeptracker/types/Bed';
 import { Controller } from 'Sleeptracker/types/Controller';
 import { sendAdjustableBaseCommand } from 'Sleeptracker/requests/sendAdjustableBaseCommand';
@@ -26,6 +26,7 @@ export const setupMotorEntities = async (
   { deviceData }: Bed,
   {
     user,
+    sideName,
     entities,
     capability: {
       motorRoster: { head, foot, headTilt: tilt, lumber: lumbar },
@@ -54,6 +55,6 @@ export const setupMotorEntities = async (
       await sendAdjustableBaseCommand(newCommand, user);
       cache.motorState = {};
     };
-    new Cover(mqtt, deviceData, buildEntityConfig(name), coverCommand).setOnline();
+    new Cover(mqtt, deviceData, buildEntityConfig(getString(name), sideName), coverCommand).setOnline();
   }
 };


### PR DESCRIPTION
## Problem

On a dual-controller Sleeptracker bed (a split-king where both sides share one processor), the adjustable-base motor covers are created without a side name, so both sides collide on the same `unique_id` / MQTT topic and only one side's Head/Feet covers ever reach Home Assistant. Full write-up in #94.

## Fix

`setupMotorEntities` was the only Sleeptracker per-side processor importing `buildEntityConfig` from `Common/` and not passing the controller `sideName`. This threads `sideName` through `Sleeptracker/buildEntityConfig` (resolving the motor `StringsKey` via `getString` first), matching `presetButtons`, `massageButtons`, `bedPositionSensors`, `snoreReliefSwitches`, and `safetyLightSwitches`.

- Dual-controller beds now get `Head: Left` / `Head: Right`, etc. — distinct `unique_id`s/topics, no collision.
- Single-controller beds resolve to an empty `sideName` and are **unchanged** (`Head` / `Feet` as before).

## Tests

Added `motorEntities.test.ts`:
- a dual-controller bed yields side-suffixed, non-colliding cover `unique_id`s (this case fails on the current code),
- a single-controller bed keeps the un-suffixed names (backward compatibility).

`yarn test:ci` → 101 passing; `yarn build` clean; changed files lint clean.

> Note: this is the first test on a `Sleeptracker/processors/` module — the existing suite covers the HA entity primitives (`HomeAssistant/`) and utils. It reuses the same harness as e.g. `Button.test.ts` (`jest-mock-extended`, `testHelpers`/`testDevice`, fake timers, asserting the published discovery config). Happy to drop it if you'd prefer to keep `processors/` test-free — the one-line fix stands on its own.

## Verified on hardware

Built and deployed against a real Tempur-Pedic split cal-king. Before: a single `Head` / `Feet` cover pair. After: `cover.…_head_left`, `…_head_right`, `…_feet_left`, `…_feet_right` all present and independently addressable.

Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)
