### PR TITLE
(Sleeptracker) Add Wave Form massage controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+**New Features**
+
+- (Sleeptracker) Add Wave Form™ massage controls (per-side select with duration)
+
 ## v1.1.22
 
 **New Features**

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ e.g.
 - Sensors for Heat & Foot Angle
 - Buttons to step thru the massage strengths, patterns & timer (auto turn off massage)
 - Sensors for Massage strengths and patterns
+- Selects to start Wave Form™ massage (per-side, with a duration select)
 - Support for split beds, and multiple beds
 - Covers to control motors for raising, lowering, and stopping the head/feet/tilt/lumbar
 

--- a/src/HomeAssistant/base/StatefulEntity.ts
+++ b/src/HomeAssistant/base/StatefulEntity.ts
@@ -45,6 +45,15 @@ export class StatefulEntity<T> extends Entity implements IStateful<T> {
     return this.state;
   }
 
+  // Re-publish the current state even if unchanged. Publishes aren't retained,
+  // so a one-shot setState can lose the race with Home Assistant's discovery
+  // processing (leaving the entity "unknown"). Call this each poll for entities
+  // whose state would otherwise never be re-sent.
+  resendState() {
+    if (this.getState() !== undefined) this.sendState();
+    return this;
+  }
+
   private sendState() {
     setTimeout(() => {
       const message = this.mapState(this.state);

--- a/src/Sleeptracker/processors/waveFormControls.ts
+++ b/src/Sleeptracker/processors/waveFormControls.ts
@@ -1,0 +1,102 @@
+import { Select } from '@ha/Select';
+import { IMQTTConnection } from '@mqtt/IMQTTConnection';
+import { buildEntityConfig } from 'Sleeptracker/buildEntityConfig';
+import { sendAdjustableBaseCommand } from '../requests/sendAdjustableBaseCommand';
+import { sendMotorAnimationCommand } from '../requests/sendMotorAnimationCommand';
+import { Bed } from '../types/Bed';
+import { Commands } from '../types/Commands';
+import { Controller } from '../types/Controller';
+
+// Wave Form™ massage options, reverse-engineered from the Tempur/Sleeptracker app.
+// The app sends a "frequency" statement (the raw value below) plus a "pulse"
+// statement whose value is a per-frequency mapping. Names match the app's own
+// therapeutic labels for each frequency.
+const WAVE_FORMS: { name: string; frequency: number; pulse: number }[] = [
+  { name: '28Hz Sleeplessness', frequency: 28, pulse: 4 },
+  { name: '40Hz Mood', frequency: 40, pulse: 5 },
+  { name: '52Hz Back Pain', frequency: 52, pulse: 3 }, // app default
+  { name: '68Hz Neck Pain', frequency: 68, pulse: 2 },
+  { name: '88Hz Headache', frequency: 88, pulse: 1 },
+];
+const OFF = 'Off';
+const DEFAULT_DURATION = '105'; // app maximum; matches the app's duration picker (5..105 by 5)
+const DURATION_OPTIONS = Array.from({ length: 21 }, (_, i) => `${(i + 1) * 5}`); // 5..105
+
+interface WaveFormEntities {
+  waveFormDuration?: Select;
+  waveForm?: Select;
+}
+
+const buildWaveFormStatements = (side: 0 | 1, frequency: number, pulse: number, durationMinutes: number) => [
+  {
+    type: 'command',
+    startDelayMs: 0,
+    command: {
+      massage: {
+        position: { side, location: 'ignore_this' }, // literal value the app sends for this field
+        action: 'pulse',
+        value: pulse,
+        duration: durationMinutes * 600,
+      },
+    },
+  },
+  {
+    type: 'command',
+    startDelayMs: 500,
+    command: {
+      massage: {
+        position: { side },
+        action: 'frequency',
+        value: frequency,
+      },
+    },
+  },
+];
+
+export const setupWaveFormControls = async (
+  mqtt: IMQTTConnection,
+  { deviceData }: Bed,
+  { sideName, side, user, entities, capability: { massageRoster } }: Controller
+) => {
+  const cache = entities as WaveFormEntities;
+  if (!(massageRoster.head || massageRoster.foot)) {
+    cache.waveForm?.setOffline();
+    cache.waveFormDuration?.setOffline();
+    return;
+  }
+
+  if (!cache.waveFormDuration) {
+    cache.waveFormDuration = new Select(
+      mqtt,
+      deviceData,
+      { ...buildEntityConfig('Wave Form Duration (min)', sideName), options: DURATION_OPTIONS },
+      async () => undefined
+    );
+    cache.waveFormDuration.setState(DEFAULT_DURATION);
+  }
+  cache.waveFormDuration.resendState();
+  cache.waveFormDuration.setOnline();
+
+  if (!cache.waveForm) {
+    cache.waveForm = new Select(
+      mqtt,
+      deviceData,
+      { ...buildEntityConfig('Wave Form', sideName), options: [OFF, ...WAVE_FORMS.map((w) => w.name)] },
+      async (selection) => {
+        if (selection === OFF) {
+          await sendAdjustableBaseCommand(Commands.MassageStop, user, { massageAdjustment: 0, requestStatus: true });
+          return OFF;
+        }
+        const wave = WAVE_FORMS.find((w) => w.name === selection);
+        if (!wave) return OFF;
+        const durationMinutes =
+          parseInt(cache.waveFormDuration?.getState() || DEFAULT_DURATION, 10) || parseInt(DEFAULT_DURATION, 10);
+        await sendMotorAnimationCommand(buildWaveFormStatements(side, wave.frequency, wave.pulse, durationMinutes), user);
+        return selection;
+      }
+    );
+    cache.waveForm.setState(OFF);
+  }
+  cache.waveForm.resendState();
+  cache.waveForm.setOnline();
+};

--- a/src/Sleeptracker/requests/sendMotorAnimationCommand.ts
+++ b/src/Sleeptracker/requests/sendMotorAnimationCommand.ts
@@ -1,0 +1,44 @@
+import { Dictionary } from '@utils/Dictionary';
+import { logError } from '@utils/logger';
+import axios from 'axios';
+import { Credentials } from '../options';
+import { getAuthHeader } from './getAuthHeader';
+import defaultHeaders from './shared/defaultHeaders';
+import { buildDefaultPayload } from './shared/defaultPayload';
+import { urls } from './shared/urls';
+
+type Response = { statusCode: number; statusMessage: string };
+
+// Sends a "motor-animation" processor command (a sequence of massage statements).
+// This is the API the Tempur/Sleeptracker app uses for Wave Form massage:
+//   POST /processor/processorCommand
+//   { endpoint: "/command/v1/motor-animation",
+//     processorCommand: { statement: { type: "sequence", statements: [...] } } }
+export const sendMotorAnimationCommand = async (statements: Dictionary<any>[], credentials: Credentials) => {
+  const authHeader = await getAuthHeader(credentials);
+  if (!authHeader) return;
+
+  const { appHost, processorBaseUrl } = urls(credentials);
+  try {
+    const response = await axios.request<Response>({
+      method: 'POST',
+      url: `${processorBaseUrl}/processorCommand`,
+      headers: {
+        ...defaultHeaders,
+        Host: appHost,
+        Authorization: authHeader,
+      },
+      data: {
+        ...buildDefaultPayload('adjustableBaseControls', credentials),
+        endpoint: '/command/v1/motor-animation',
+        processorCommand: { statement: { type: 'sequence', statements } },
+      },
+    });
+    const { statusCode } = response.data;
+    if (statusCode !== 0) {
+      logError('[Sleeptracker]', JSON.stringify(response.data));
+    }
+  } catch (err) {
+    logError(err);
+  }
+};

--- a/src/Sleeptracker/sleeptracker.ts
+++ b/src/Sleeptracker/sleeptracker.ts
@@ -13,6 +13,7 @@ import { processBedPositionSensors } from './processors/bedPositionSensors';
 import { processEnvironmentSensors } from './processors/environmentSensors';
 import { setupMassageButtons } from './processors/massageButtons';
 import { processMassageSensors } from './processors/massageSensors';
+import { setupWaveFormControls } from './processors/waveFormControls';
 import { setupPresetButtons } from './processors/presetButtons';
 import { processSafetyLightSwitches } from './processors/safetyLightSwitches';
 import { processSnoreReliefSwitches } from './processors/snoreReliefSwitches';
@@ -117,6 +118,7 @@ export const sleeptracker = async (mqtt: IMQTTConnection) => {
         for (const controller of bed.controllers) {
           await setupPresetButtons(mqtt, bed, controller);
           await setupMassageButtons(mqtt, bed, controller);
+          await setupWaveFormControls(mqtt, bed, controller);
           if (motors) await setupMotorEntities(mqtt, bed, controller);
 
           await processSnoreReliefSwitches(mqtt, bed, controller);

--- a/src/Sleeptracker/types/Commands.ts
+++ b/src/Sleeptracker/types/Commands.ts
@@ -47,5 +47,8 @@ export enum Commands {
   MassagePatternStep = 226,
   MassageTimerStep = 231,
 
+  // Stops all massagers (app a.d.STOP_MASSAGERS). Used to stop Wave Form massage.
+  MassageStop = 30,
+
   ToggleSafetyLights = 230,
 }

--- a/src/Sleeptracker/types/Snapshot.ts
+++ b/src/Sleeptracker/types/Snapshot.ts
@@ -17,6 +17,7 @@ export enum MassagePattern {
   Pulse = 1,
   Constant = 2,
   Ripple = 3,
+  Wave = 4,
 }
 
 export type Snapshot = {


### PR DESCRIPTION
## What

Adds support for **Wave Form™ massage** to the Sleeptracker (Tempur/Sleeptracker) integration, so it can be started and stopped from Home Assistant instead of the phone app.

Two new per-side `select` entities are added to the bed device:

- **Wave Form** — `Off` plus the app's five presets, labelled with the app's own therapeutic names: `28Hz Sleeplessness`, `40Hz Mood`, `52Hz Back Pain`, `68Hz Neck Pain`, `88Hz Headache`.
- **Wave Form Duration (min)** — `5`…`105` in steps of 5 (matches the app's picker; default `105`).

Selecting a wave form starts the massage; selecting `Off` stops it.

## How it works

Wave Form isn't a numeric `bedControlCommand`. The app POSTs a `motor-animation` processor command to `/processor/processorCommand`:

```json
{
  "endpoint": "/command/v1/motor-animation",
  "processorCommand": { "statement": { "type": "sequence", "statements": [ <pulse>, <frequency> ] } }
}
```

i.e. a `pulse` statement (value = a per-frequency mapping, plus `duration = minutes * 600`) followed 500 ms later by a `frequency` statement (value = 28/40/52/68/88). This was reverse-engineered from the app; the five presets and their paired pulse values are encoded in `WAVE_FORMS`.

`Off` stops all massagers via the existing adjustable-base command path using `STOP_MASSAGERS` (30).

## Changes

- **New** `requests/sendMotorAnimationCommand.ts` — sends a `motor-animation` sequence (mirrors `sendAdjustableBaseCommand`).
- **New** `processors/waveFormControls.ts` — the two select entities + command building.
- `types/Commands.ts` — add `MassageStop = 30`.
- `types/Snapshot.ts` — add `MassagePattern.Wave = 4` (so the existing massage-pattern sensor decodes Wave Form instead of showing blank).
- `sleeptracker.ts` — wire `setupWaveFormControls` into the controller refresh loop.
- `HomeAssistant/base/StatefulEntity.ts` — add `resendState()`. Publishes aren't retained, so a one-shot `setState` on a select can lose the race with HA's discovery processing and leave the entity `unknown`; the wave-form selects re-assert their state each poll (also restores state after an HA restart).
- README / CHANGELOG.

## Testing

Tested live against a Tempur/Sleeptracker (Ergo) bed:

- Selecting a wave form starts the massage on the bed (cloud returns `statusCode 0`); physically confirmed.
- Selecting `Off` stops it.
- Both selects report correct state after add-on/HA restarts.
- `tsc` and `eslint --max-warnings=0` clean.

Note: the head/foot massage-strength sensors read 0 during wave form (it's frequency/pulse based, not the 0–3 intensity massage) — expected, not a regression.

Labels are generic-but-ordered where they came from an obfuscated app resource; happy to adjust wording or entity naming to match project conventions.