### PR TITLE
Fix/97 sleeptracker null bed name

### DIFF
--- a/src/Sleeptracker/buildMQTTDeviceData.test.ts
+++ b/src/Sleeptracker/buildMQTTDeviceData.test.ts
@@ -3,7 +3,7 @@ import { buildMQTTDeviceData } from './buildMQTTDeviceData';
 import { Device } from './types/Device';
 
 const device = {
-  sleeptrackerProcessorID: 1241473,
+  sleeptrackerProcessorID: 1234567,
   modelID: 'STS60',
   mattressBrandName: 'Tempur-Pedic',
 } as Device;
@@ -31,7 +31,7 @@ describe(buildMQTTDeviceData.name, () => {
   it('falls back to the processor id when the API omits the name', () => {
     const { device: result } = buildMQTTDeviceData({ ...device, name: null as unknown as string });
 
-    expect(result.name).toEqual('Sleeptracker 1241473');
-    expect(safeId(result.name)).toEqual('sleeptracker_1241473');
+    expect(result.name).toEqual('Sleeptracker 1234567');
+    expect(safeId(result.name)).toEqual('sleeptracker_1234567');
   });
 });

--- a/src/Sleeptracker/buildMQTTDeviceData.test.ts
+++ b/src/Sleeptracker/buildMQTTDeviceData.test.ts
@@ -1,0 +1,37 @@
+import { safeId } from '@utils/safeId';
+import { buildMQTTDeviceData } from './buildMQTTDeviceData';
+import { Device } from './types/Device';
+
+const device = {
+  sleeptrackerProcessorID: 1241473,
+  modelID: 'STS60',
+  mattressBrandName: 'Tempur-Pedic',
+} as Device;
+
+describe(buildMQTTDeviceData.name, () => {
+  it('uses the name the API supplied', () => {
+    const { device: result } = buildMQTTDeviceData({ ...device, name: 'Bedroom' });
+
+    expect(result.name).toEqual('Bedroom');
+    expect(safeId(result.name)).toEqual('bedroom');
+  });
+
+  // Documents the mechanism behind #97: whatever buildMQTTDeviceData puts in
+  // device.name reaches safeId unguarded from Entity's constructor.
+  it('crashes the way #97 reports when the name reaches safeId as null', () => {
+    expect(() => safeId(null as unknown as string)).toThrow(
+      "Cannot read properties of null (reading 'toLowerCase')"
+    );
+  });
+
+  // Accounts created through Sleeptracker's "Add Second Sleeper" invite flow come
+  // back with a null name, because the bed is named by whoever registered the
+  // processor. Entity's constructor passes device.name straight to safeId, so the
+  // null crashed the add-on on the first entity it built.
+  it('falls back to the processor id when the API omits the name', () => {
+    const { device: result } = buildMQTTDeviceData({ ...device, name: null as unknown as string });
+
+    expect(result.name).toEqual('Sleeptracker 1241473');
+    expect(safeId(result.name)).toEqual('sleeptracker_1241473');
+  });
+});

--- a/src/Sleeptracker/buildMQTTDeviceData.ts
+++ b/src/Sleeptracker/buildMQTTDeviceData.ts
@@ -11,7 +11,7 @@ export const buildMQTTDeviceData = ({
     deviceTopic: `sleeptracker/${processorId}`,
     device: {
       ids: [`${processorId}`],
-      name: name,
+      name: name || `Sleeptracker ${processorId}`,
       mf: mattressBrandName || 'Sleeptracker',
       mdl: modelID,
     },

--- a/src/Sleeptracker/sleeptracker.ts
+++ b/src/Sleeptracker/sleeptracker.ts
@@ -32,7 +32,8 @@ export const sleeptracker = async (mqtt: IMQTTConnection) => {
   for (const user of users) {
     const devices = await getDevices(user);
     if (devices.length === 0) {
-      return logError('[Sleeptracker] Could not load devices');
+      logError('[Sleeptracker] Could not load devices');
+      continue;
     }
     for (const device of devices) {
       const { sleeptrackerProcessorID: processorId } = device;


### PR DESCRIPTION
# (Sleeptracker) Fix crash when the API returns no bed name — closes #97

## Problem

Configuring a Sleeptracker account created through the **"Add Second Sleeper"**
invite flow crashes the add-on on startup, a few seconds after MQTT connects:

```
error TypeError: Cannot read properties of null (reading 'toLowerCase')
```

Reported in #97, where it also reproduces with the invited account configured
on its own, so it isn't an interaction between two accounts.

## Cause

For a split base, `getByType` returns one device per processor. The processor
belonging to the invited sleeper comes back with `name: null` — the bed is named
by whoever registered it, and that name isn't populated in the invited user's
view of the device.

`buildMQTTDeviceData` passes it straight through:

```ts
name: name,
mf: mattressBrandName || 'Sleeptracker',   // neighbouring field is already guarded
```

`Entity`'s constructor then hands it to `safeId` unguarded:

```ts
this.uniqueId = `${safeId(deviceData.device.name)}_${this.entityTag}`;
```

and `safeId` calls `.toLowerCase()` on it. `DeviceInfoSensor` is the first entity
built, so the add-on dies before publishing anything — including for the
processor it had already read successfully.

`types/Device.ts` declares `name: string`, which is why the compiler never
flagged it.

## Changes

1. **`buildMQTTDeviceData.ts`** — fall back to the processor id when the API
   omits the name, matching the `mattressBrandName || 'Sleeptracker'` idiom on
   the following line. Happy to use a different fallback string if you'd prefer
   something else.

2. **`sleeptracker.ts`** — `continue` rather than `return` when a user returns
   zero devices. At present one account failing to load aborts the loop over all
   remaining users, so a single bad credential silently takes out every other
   configured account.

3. **`buildMQTTDeviceData.test.ts`** (new) — covers the normal path, the null
   path, and pins the exact error string so the regression can't return quietly.

## Verification

Unit: `yarn test:ci` 15 suites / 102 tests passing, `yarn build` clean, no new
eslint findings.

Real hardware: a Tempur split base whose second processor belongs to an invited
"Add Second Sleeper" account. Before this change the add-on crashed on startup
exactly as #97 describes, and only the primary processor was ever served. After
it, both processors are polled every cycle, the invited one is published under
the fallback name, and every entity for both sides comes up normally. Running in
production since 2026-08-03 with no crashes.

## Note for reviewers

Entity `uniqueId`s derive from `device.name`, and `buildMQTTDeviceData` only runs
on first sight of a bed (`if (!bed)`). So where two accounts share one bed, the
name is set by whichever is processed first. Existing users upgrading should keep
the account that has a real bed name first in `sleeptrackerCredentials` —
otherwise the fallback name would change every `uniqueId` and Home Assistant
would create a duplicate device alongside the original. 